### PR TITLE
URI-encode sitemap URLs

### DIFF
--- a/lib/hexdocs/utils.ex
+++ b/lib/hexdocs/utils.ex
@@ -8,7 +8,7 @@ defmodule Hexdocs.Utils do
     host = Application.get_env(:hexdocs, :host)
     scheme = if host == "hexdocs.pm", do: "https", else: "http"
     subdomain = if repository == "hexpm", do: "", else: "#{repository}."
-    "#{scheme}://#{subdomain}#{host}#{path}"
+    URI.encode("#{scheme}://#{subdomain}#{host}#{path}")
   end
 
   def latest_version(versions) do


### PR DESCRIPTION
Hi, I came across a couple of invalid URLs in package sitemaps on hexdocs.pm .

The [sitemaps.org specs](https://sitemaps.org/protocol.html#escaping) state that URLs (`<loc>` element values) should be URL-encoded and entity-escaped. Special characters include spaces, which are sometime present in directory names and filenames.

I didn't see any test for this, but just let me know if I missed something and I'll try and fix it.